### PR TITLE
corrected version of the 2x2 LSTSQ sample/probe joint step length computation

### DIFF
--- a/src/ptychi/ptychotorch/reconstructors/lsqml.py
+++ b/src/ptychi/ptychotorch/reconstructors/lsqml.py
@@ -312,19 +312,23 @@ class LSQMLReconstructor(AnalyticalIterativePtychographyReconstructor):
         delta_p_o = delta_p_i * obj_patches[:, None, :, :]
         delta_o_patches_p = delta_o_i[:, None, :, :] * probe
 
-        # Shape of aij:               (batch_size,)
-        a11 = (delta_o_patches_p.abs() ** 2).sum(-1).sum(-1).sum(-1) + gamma
-        a12 = (delta_o_patches_p * delta_p_o.conj()).sum(-1).sum(-1).sum(-1)
-        a21 = a12.conj()
-        a22 = (delta_p_o.abs() ** 2).sum(-1).sum(-1).sum(-1) + gamma
-        b1 = torch.real(delta_o_patches_p.conj() * chi).sum(-1).sum(-1).sum(-1)
-        b2 = torch.real(delta_p_o.conj() * chi).sum(-1).sum(-1).sum(-1)
+        # NOTE: FoldSlice does not use real() for off-diagonal terms, and it only computes this for the dominant mode (we use all incoherent modes here)
+        # sum over r (spatial pixel index), p (incoherent mode index)
+        a11 = torch.sum(delta_o_patches_p.abs() ** 2, dim=(-1, -2, -3)) + gamma
+        a11 += 0.5 * torch.mean(a11, dim=0)
+        a22 = torch.sum(delta_p_o.abs() ** 2, dim=(-1, -2, -3)) + gamma
+        a22 += 0.5 * torch.mean(a22, dim=0)
+        a12 = torch.sum(torch.real(delta_o_patches_p * delta_p_o.conj()), dim=(-1, -2, -3))
+        a21 = a12
+        b1 = torch.sum(torch.real(delta_o_patches_p.conj() * chi), dim=(-1, -2, -3))
+        b2 = torch.sum(torch.real(delta_p_o.conj() * chi), dim=(-1, -2, -3))
 
         a_mat = torch.stack([a11, a12, a21, a22], dim=1).view(-1, 2, 2)
         b_vec = torch.stack([b1, b2], dim=1).view(-1, 2).type(a_mat.dtype)
         alpha_vec = torch.linalg.solve(a_mat, b_vec)
-        alpha_vec = alpha_vec.abs()
-        
+
+        alpha_vec = torch.where(alpha_vec < 0, 0, alpha_vec)
+
         alpha_o_i = alpha_vec[:, 0]
         alpha_p_i = alpha_vec[:, 1]
 


### PR DESCRIPTION
The joint step length computation in FoldSlice as well as what's currently in pty-chi has incorrect off-diagonal elements in the 2x2 matrix equation (all the 2x2 matrix elements should be real valued); Ming and I have gone through the math and agree that the correction I introduce here is the mathematically correct one.