### PR TITLE
small feature addition: use probe intensity for com shift

### DIFF
--- a/src/ptychi/api/options/base.py
+++ b/src/ptychi/api/options/base.py
@@ -501,6 +501,13 @@ class ProbeCenterConstraintOptions(FeatureOptions):
     enabled: bool = False
 
     optimization_plan: OptimizationPlan = dataclasses.field(default_factory=OptimizationPlan)
+    
+    use_intensity_for_com: bool = False
+    """
+    Whether to use the dominant shared probe mode for computing
+    the center of mass of the probe in order to keep it centered, 
+    or to use the probe intensity.
+    """
 
 
 @dataclasses.dataclass

--- a/src/ptychi/api/options/base.py
+++ b/src/ptychi/api/options/base.py
@@ -504,9 +504,9 @@ class ProbeCenterConstraintOptions(FeatureOptions):
     
     use_intensity_for_com: bool = False
     """
-    Whether to use the dominant shared probe mode for computing
-    the center of mass of the probe in order to keep it centered, 
-    or to use the probe intensity.
+    Whether to use the magnitude of the dominant shared probe 
+    mode for computing the center of mass of the probe in order 
+    to keep it centered, or to use the total probe intensity.
     """
 
 

--- a/src/ptychi/data_structures/probe.py
+++ b/src/ptychi/data_structures/probe.py
@@ -396,7 +396,7 @@ class Probe(dsbase.ReconstructParameter):
         """
         
         if self.options.center_constraint.use_intensity_for_com:
-            probe_to_be_shifted = torch.sum( torch.abs( self.data[0,...] ) ** 2, dim=0 )
+            probe_to_be_shifted = torch.sum(torch.abs(self.data[0,...])**2, dim=0)
         else:
             probe_to_be_shifted = self.get_mode_and_opr_mode(0, 0)
         

--- a/src/ptychi/data_structures/probe.py
+++ b/src/ptychi/data_structures/probe.py
@@ -394,7 +394,13 @@ class Probe(dsbase.ReconstructParameter):
         """
         Move the probe's center of mass to the center of the probe array.
         """
-        com = ip.find_center_of_mass(self.get_mode_and_opr_mode(0, 0))
+        
+        if self.options.center_constraint.use_intensity_for_com:
+            probe_to_be_shifted = torch.sum( torch.abs( self.data[0,...] ) ** 2, 0 )
+        else:
+            probe_to_be_shifted = self.get_mode_and_opr_mode(0, 0)
+        
+        com = ip.find_center_of_mass(probe_to_be_shifted)
         shift = utils.to_tensor(self.shape[-2:]) // 2 - com
         shifted_probe = self.shift(shift)
         self.set_data(shifted_probe)

--- a/src/ptychi/data_structures/probe.py
+++ b/src/ptychi/data_structures/probe.py
@@ -396,7 +396,7 @@ class Probe(dsbase.ReconstructParameter):
         """
         
         if self.options.center_constraint.use_intensity_for_com:
-            probe_to_be_shifted = torch.sum( torch.abs( self.data[0,...] ) ** 2, 0 )
+            probe_to_be_shifted = torch.sum( torch.abs( self.data[0,...] ) ** 2, dim=0 )
         else:
             probe_to_be_shifted = self.get_mode_and_opr_mode(0, 0)
         

--- a/src/ptychi/data_structures/probe.py
+++ b/src/ptychi/data_structures/probe.py
@@ -396,7 +396,7 @@ class Probe(dsbase.ReconstructParameter):
         """
         
         if self.options.center_constraint.use_intensity_for_com:
-            probe_to_be_shifted = torch.sum(torch.abs(self.data[0,...])**2, dim=0)
+            probe_to_be_shifted = torch.sum(torch.abs(self.data[0, ...]) ** 2, dim=0)
         else:
             probe_to_be_shifted = self.get_mode_and_opr_mode(0, 0)
         


### PR DESCRIPTION
# Features/fixes

The default behavior is to use the 0th order shared probe mode to compute the center of mass (com); this adds the option of using the probe intensity as well.

# Related issues (optional)

N/A

# Mentions

Ming Du

# Checklist

Have you...
- [ ] Formatted your code properly adhering to PEP-8? Considering using RUFF to format your code automatically.
- [ ] Resolved all merge conflicts with the main branch?
- [ ] Checked the diffs between your branch and the main branch to ensure that your changes are not introducing any regressions or unnecessary/irrelevant changes?
