### PR TITLE
probe power constraint scaling and fft using backward normalization

### DIFF
--- a/src/ptychi/data_structures/probe.py
+++ b/src/ptychi/data_structures/probe.py
@@ -366,8 +366,8 @@ class Probe(dsbase.ReconstructParameter):
 
         # TODO: use propagator for forward simulation
         propagated_probe = propagator.propagate_forward(probe_composed)
-        propagated_probe_power = torch.sum(propagated_probe.abs() ** 2)
-        power_correction = torch.sqrt(self.probe_power / propagated_probe_power)
+        propagated_probe_power = torch.sum(propagated_probe.abs() ** 2) / self.data.size().numel()
+        power_correction = torch.sqrt(self.probe_power / propagated_probe_power) 
 
         self.set_data(self.data * power_correction)
         object_.set_data(object_.data / power_correction)


### PR DESCRIPTION
When using the probe power constraint, because of the way PtyChi does fft scaling, the power the probe gets scaled to is P / N^2 (where the array size of the probe is N x N) instead of P. 

This small fix should account for this; alternatively we can initialize the probe power constraint to be P * N^2 and not use this small fix, but that seems like a clunky way of doing things?

Another way to account for this is to not use the propagate_forward() part of the code, directly compute the probe norm e.g. torch.sum(probe_composed.abs() ** 2), and then rescale the probe and sample using this power correction?