### PR TITLE
Update copy operation

### DIFF
--- a/src/ptychi/pear_io_aps.py
+++ b/src/ptychi/pear_io_aps.py
@@ -447,7 +447,7 @@ def save_reconstructions(task, recon_path, iter, params):
             print(
                 f"\nSaving final object phase to {obj_ph_collection_dir}/S{params['scan_num']:04d}.tiff"
             )
-            shutil.copy(
+            shutil.copyfile(
                 f"{recon_path}/object_ph/object_ph_Niter{iter}.tiff",
                 f"{obj_ph_collection_dir}/S{params['scan_num']:04d}.tiff"
             )
@@ -463,7 +463,7 @@ def save_reconstructions(task, recon_path, iter, params):
             print(
                 f"\nSaving final probe magnitude to {probe_mag_collection_dir}/S{params['scan_num']:04d}.tiff"
             )
-            shutil.copy(
+            shutil.copyfile(
                 f"{recon_path}/probe_mag/probe_mag_Niter{iter}.tiff",
                 f"{probe_mag_collection_dir}/S{params['scan_num']:04d}.tiff"
             )


### PR DESCRIPTION
The shutil.copy function was raising a PermissionsError because it attempts to change the permissions of the copied file, and I was not the owner of the copied file. I was able to fix it by changing it to shutil.copyfile. shutil.copy attempts to change the permissions of the copied file, while shutil.copyfile only copies the file.