### PR TITLE
Supporting non-NVIDIA GPUs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,17 @@ How to run test scripts
    repository: ``export PTYCHO_CI_DATA_DIR="path_to_data_repo/ci_data"``.
 4. Run any test scripts in ``tests`` with Python.
 
+======================
+To use GPUs of alternative vendors
+======================
+
+Pty-Chi works on GPUs from different vendors than NVidia. For example, Intel.
+To run Pty-Chi with Intel GPUs, add these lines right after importing `torch`
+and `ptychi`::
+
+   torch.set_default_device("xpu")
+   ptychi.device.set_torch_accelerator_module(torch.xpu)
+
 
 ======================
 Reading documentations

--- a/src/ptychi/device.py
+++ b/src/ptychi/device.py
@@ -3,8 +3,34 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from types import ModuleType
 
 import torch
+
+
+_torch_accelerator_module = torch.cuda
+
+
+class AcceleratorModuleWrapper:
+    """A wrapper class for the accelerator device module of PyTorch.
+    """
+    
+    @classmethod
+    def get_module(cls) -> ModuleType:
+        return get_torch_accelerator_module()
+    
+    @classmethod
+    def set_module(cls, module: ModuleType):
+        set_torch_accelerator_module(module)
+        
+    @classmethod
+    def get_to_device_string(cls) -> str:
+        if cls.get_module() == torch.cuda:
+            return "cuda"
+        elif cls.get_module() == torch.xpu:
+            return "xpu"
+        else:
+            raise ValueError(f"Unsupported accelerator module: {cls.get_module()}")
 
 
 @dataclass(frozen=True)
@@ -17,19 +43,43 @@ class Device:
     def torch_device(self) -> str:
         return f"{self.backend.lower()}:{self.ordinal}"
 
+
 def list_available_devices() -> Sequence[Device]:
     available_devices = list()
-
-    if torch.cuda.is_available():
-        for ordinal in range(torch.cuda.device_count()):
-            name = torch.cuda.get_device_name(ordinal)
-            device = Device("cuda", ordinal, name)
-            available_devices.append(device)
-
-    if torch.xpu.is_available():
-        for ordinal in range(torch.xpu.device_count()):
-            name = torch.xpu.get_device_name(ordinal)
-            device = Device("xpu", ordinal, name)
+    accelerator_module_wrapper = AcceleratorModuleWrapper()
+    accelerator_module = accelerator_module_wrapper.get_module()
+    
+    if accelerator_module.is_available():
+        for ordinal in range(accelerator_module.device_count()):
+            name = accelerator_module.get_device_name(ordinal)
+            device = Device(accelerator_module_wrapper.get_to_device_string(), ordinal, name)
             available_devices.append(device)
 
     return available_devices
+
+
+def set_torch_accelerator_module(module: ModuleType):
+    """Set the global variable of the torch accelerator module. 
+    By default, it is `torch.cuda`.
+    
+    For Intel GPUs, use `torch.xpu`.
+    
+    Parameters
+    ----------
+    module: ModuleType
+        The torch accelerator module.
+    """
+    global _torch_accelerator_module
+    _torch_accelerator_module = module
+
+
+def get_torch_accelerator_module() -> ModuleType:
+    """Get the global variable of the torch accelerator module. 
+    By default, it is `torch.cuda`.
+    
+    Returns
+    -------
+    ModuleType
+        The torch accelerator module.
+    """
+    return _torch_accelerator_module

--- a/src/ptychi/io_handles.py
+++ b/src/ptychi/io_handles.py
@@ -14,6 +14,7 @@ import sklearn.cluster
 import numpy as np
 import scipy.spatial
 
+from ptychi.device import AcceleratorModuleWrapper
 from ptychi.utils import to_tensor, to_numpy
 import ptychi.maths as pmath
 
@@ -33,7 +34,7 @@ class PtychographyDataset(Dataset):
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.patterns = to_tensor(patterns, device="cpu" if not save_data_on_device else "cuda")
+        self.patterns = to_tensor(patterns, device="cpu" if not save_data_on_device else AcceleratorModuleWrapper.get_to_device_string())
         if fft_shift:
             self.patterns = torch.fft.fftshift(self.patterns, dim=(-2, -1))
             logger.info("Diffraction data have been FFT-shifted.")

--- a/src/ptychi/maps.py
+++ b/src/ptychi/maps.py
@@ -2,6 +2,7 @@
 # Full license accessible at https://github.com//AdvancedPhotonSource/pty-chi/blob/main/LICENSE
 
 from typing import Type
+from functools import partial
 
 import torch
 
@@ -12,8 +13,7 @@ import ptychi.forward_models as fm
 from ptychi.reconstructors.base import Reconstructor
 import ptychi.image_proc as ip
 import ptychi.reconstructors.nn as pnn
-from functools import partial
-
+from ptychi.device import AcceleratorModuleWrapper
 
 def get_complex_dtype_by_enum(key: enums.Dtypes) -> torch.dtype:
     return {enums.Dtypes.FLOAT32: torch.complex64, enums.Dtypes.FLOAT64: torch.complex128}[key]
@@ -67,7 +67,7 @@ def get_noise_model_by_enum(key: enums.NoiseModels) -> str:
 
 
 def get_device_by_enum(key: enums.Devices) -> str:
-    return {enums.Devices.CPU: "cpu", enums.Devices.GPU: "cuda"}[key]
+    return {enums.Devices.CPU: "cpu", enums.Devices.GPU: AcceleratorModuleWrapper.get_to_device_string()}[key]
 
 
 def get_dtype_by_enum(key: enums.Dtypes) -> torch.dtype:

--- a/src/ptychi/timing/timer_utils.py
+++ b/src/ptychi/timing/timer_utils.py
@@ -7,8 +7,9 @@ from typing import Callable, TypeVar, Optional, List, Dict, Union
 import numpy as np
 import matplotlib.pyplot as plt
 import copy
-import torch
 from collections import defaultdict
+
+from ptychi.device import AcceleratorModuleWrapper
 
 
 # Type variables to retain function signatures
@@ -95,10 +96,10 @@ def timer(enabled: bool = True, override_with_name: Optional[str] = None):
                 overhead_time_1 = time.time() - measure_overhead_start_1
 
                 # Measure function execution time
-                torch.cuda.synchronize()
+                AcceleratorModuleWrapper.get_module().synchronize()
                 start_time = time.time()
                 result = func(*args, **kwargs)
-                torch.cuda.synchronize()
+                AcceleratorModuleWrapper.get_module().synchronize()
                 elapsed_time = time.time() - start_time
 
                 # Measure the overhead from running the timer function
@@ -151,7 +152,7 @@ class InlineTimer:
             saved_dict_reference = update_current_dict_reference(self.name)
             self.saved_dict_reference = saved_dict_reference
             self.overhead_time = time.time() - measure_overhead_start
-            torch.cuda.synchronize()
+            AcceleratorModuleWrapper.get_module().synchronize()
             self.start_time = time.time()
 
     def end(self):
@@ -159,7 +160,7 @@ class InlineTimer:
         Stops the timer and records the elapsed time if timing is enabled.
         """
         if self.enabled and globals().get("ENABLE_TIMING", False):
-            torch.cuda.synchronize()
+            AcceleratorModuleWrapper.get_module().synchronize()
             elapsed_time = time.time() - self.start_time
             measure_overhead_start = time.time()
             update_elapsed_time_dict(self.name, elapsed_time)


### PR DESCRIPTION
# Features/fixes

Created a wrapper for device-related operations that used to be CUDA-specific. This includes:
  * `torch.cuda`
  * `tensor.cuda()`

To run with Intel GPUs, users should add the following to the run script:
```
torch.set_default_device("xpu")
ptychi.device.set_torch_accelerator_module(torch.xpu)
```

# Checklist

Have you...
- [x] Formatted your code properly adhering to PEP-8? Considering using RUFF to format your code automatically.
- [x] Resolved all merge conflicts with the main branch?
- [x] Checked the diffs between your branch and the main branch to ensure that your changes are not introducing any regressions or unnecessary/irrelevant changes?
