### PR TITLE
FEAT: diffraction pattern blur

### DIFF
--- a/src/ptychi/api/options/base.py
+++ b/src/ptychi/api/options/base.py
@@ -952,6 +952,11 @@ class ForwardModelOptions(Options):
     
     pad_for_shift: Optional[int] = 0
     """If not None, the image is padded with border values by this amount before shifting."""
+    
+    diffraction_pattern_blur_sigma: Optional[float] = None
+    """If not None, simulated diffraction patterns are blurred with a Gaussian kernel of
+    this sigma. This is useful to mitigate the effect of the detector's point spread function.
+    """
 
 
 @dataclasses.dataclass

--- a/src/ptychi/image_proc.py
+++ b/src/ptychi/image_proc.py
@@ -1166,7 +1166,7 @@ def convolve1d(
 
 @timer()
 def gaussian_filter(image, sigma=1, size=3):
-    x = torch.arange(-((size - 1) / 2), -((size - 1) / 2) + size, 1)
+    x = torch.arange(-((size - 1) / 2), -((size - 1) / 2) + size, 1, device=image.device)
     gauss_1d = torch.exp(-0.5 * (x / sigma) ** 2)
     kernel = gauss_1d[:, None] * gauss_1d[None, :]
     kernel = kernel / torch.sum(kernel)

--- a/src/ptychi/reconstructors/base.py
+++ b/src/ptychi/reconstructors/base.py
@@ -652,6 +652,7 @@ class AnalyticalIterativePtychographyReconstructor(
             free_space_propagation_distance_m=self.dataset.free_space_propagation_distance_m,
             pad_for_shift=self.options.forward_model_options.pad_for_shift,
             low_memory_mode=self.options.forward_model_options.low_memory_mode,
+            diffraction_pattern_blur_sigma=self.options.forward_model_options.diffraction_pattern_blur_sigma,
         )
 
     def run_post_epoch_hooks(self) -> None:

--- a/tests/test_ptycho_dp_blur.py
+++ b/tests/test_ptycho_dp_blur.py
@@ -1,0 +1,62 @@
+import argparse
+
+import torch
+import numpy as np
+
+import ptychi.api as api
+from ptychi.api.task import PtychographyTask
+from ptychi.utils import get_suggested_object_size, get_default_complex_dtype
+
+import test_utils as tutils
+
+
+class TestPtychoDpBlur(tutils.TungstenDataTester):
+    def test_ptycho_dp_blur(self):
+        name = 'test_ptycho_dp_blur'
+        
+        self.setup_ptychi(cpu_only=False)
+        
+        data, probe, pixel_size_m, positions_px = self.load_tungsten_data(pos_type='true')
+
+        options = api.LSQMLOptions()
+        options.data_options.data = data
+            
+        options.object_options.initial_guess = torch.ones([3, *get_suggested_object_size(positions_px, probe.shape[-2:], extra=100)], dtype=get_default_complex_dtype())
+        options.object_options.pixel_size_m = pixel_size_m
+        options.object_options.slice_spacings_m = np.array([3e-6, 3e-6])
+        options.object_options.optimizable = True
+        options.object_options.optimizer = api.Optimizers.SGD
+        options.object_options.step_size = 1
+        
+        options.probe_options.initial_guess = probe
+        options.probe_options.optimizable = True
+        options.probe_options.optimizer = api.Optimizers.SGD
+        options.probe_options.step_size = 1
+
+        options.probe_position_options.position_x_px = positions_px[:, 1]
+        options.probe_position_options.position_y_px = positions_px[:, 0]
+        options.probe_position_options.optimizable = False
+        
+        options.reconstructor_options.batch_size = 96
+        options.reconstructor_options.noise_model = api.NoiseModels.GAUSSIAN
+        options.reconstructor_options.num_epochs = 8
+        options.reconstructor_options.forward_model_options.diffraction_pattern_blur_sigma = 3
+        
+        task = PtychographyTask(options)
+        fm = task.reconstructor.forward_model
+        
+        y = fm.forward(torch.tensor([0, 1]).long())
+        
+        if self.debug:
+            import matplotlib.pyplot as plt
+            plt.imshow(y[0].abs().detach().cpu().numpy())
+            plt.show()    
+    
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--generate-gold', action='store_true')
+    args = parser.parse_args()
+
+    tester = TestPtychoDpBlur()
+    tester.setup_method(name="", generate_data=False, generate_gold=args.generate_gold, debug=True)
+    tester.test_ptycho_dp_blur()


### PR DESCRIPTION
# Features/fixes

Diffraction pattern blur. Enable it using `reconstructor_options.forward_model_options.diffraction_pattern_blur_sigma`. Default is None. 

# Related issues (optional)

Add links to issues related to this pull request, if any.

# Mentions

Mention team members responsible for reviewing this change. 

# Checklist

Have you...
- [x] Formatted your code properly adhering to PEP-8? Considering using RUFF to format your code automatically.
- [x] Resolved all merge conflicts with the main branch?
- [x] Checked the diffs between your branch and the main branch to ensure that your changes are not introducing any regressions or unnecessary/irrelevant changes?
